### PR TITLE
实现Box上传gist的工具函数

### DIFF
--- a/box/chavy.boxjs.js
+++ b/box/chavy.boxjs.js
@@ -505,104 +505,6 @@ async function apiRunScript() {
  * 工具类函数
  * ===================================
  */
-// gist备份工具
-function GistBox(token) {
-  const BOX_BACKUP_KEY = "BoxJs Gist";
-  const $http = HTTP("https://api.github.com", {
-    headers: {
-      Authorization: `token ${token}`,
-      "User-Agent":
-        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.141 Safari/537.36",
-    },
-    events: {
-      onResponse: (resp) => {
-        if (String(resp.statusCode).startsWith("4")) {
-          return Promise.reject(`ERROR: ${JSON.parse(resp.body).message}`);
-        } else {
-          return resp;
-        }
-      },
-    },
-  });
-  const genFileName = (timestamp) => `boxjs.bak.${timestamp}.json`;
-  const genTimestamp = (fname) => fname.match(/boxjs\.bak\.(\d+)\.json/)[1];
-
-  return new (class {
-    async findDatabase() {
-      return $http.get("/gists").then((response) => {
-        const gists = JSON.parse(response.body);
-        for (let g of gists) {
-          if (g.description === BOX_BACKUP_KEY) {
-            return g.id;
-          }
-        }
-        return -1;
-      });
-    }
-
-    async createDatabase(backups) {
-      if (!(backups instanceof Array)) backups = [backups];
-      const files = {};
-      backups.forEach((b) => {
-        files[genFileName(b.time)] = {
-          content: b.content,
-        };
-      });
-      return $http
-        .post({
-          url: "/gists",
-          body: JSON.stringify({
-            description: BOX_BACKUP_KEY,
-            public: false,
-            files,
-          }),
-        })
-        .then((resp) => {
-          return JSON.parse(resp.body).id;
-        });
-    }
-
-    async deleteDatabase(id) {
-      return $http.delete(`/gists/${id}`);
-    }
-
-    async getBackups(id) {
-      const gist = await $http
-        .get(`/gists/${id}`)
-        .then((resp) => JSON.parse(resp.body));
-      const { files } = gist;
-      const backups = [];
-      for (let name of Object.keys(files)) {
-        backups.push({
-          time: genTimestamp(name),
-          url: files[name].raw_url,
-        });
-      }
-      return backups;
-    }
-
-    async addBackups(id, backups) {
-      if (!(backups instanceof Array)) backups = [backups];
-      const files = {};
-      backups.forEach((b) => (files[genFileName(b.time)] = {content: b.content}));
-      return this.updateBackups(id, files);
-    }
-
-    async deleteBackups(id, timestamps) {
-      if (!(timestamps instanceof Array)) timestamps = [timestamps];
-      const files = {};
-      timestamps.forEach((t) => (files[genFileName(t)] = {}));
-      return this.updateBackups(id, files);
-    }
-
-    async updateBackups(id, files) {
-      return $http.patch({
-        url: `/gists/${id}`,
-        body: JSON.stringify({ files }),
-      });
-    }
-  })();
-}
 
 function reloadAppSubCache(url) {
   return $.http.get(url).then((resp) => {
@@ -732,8 +634,5 @@ function doneApi() {
 // prettier-ignore
 function Env(t,s){class e{constructor(t){this.env=t}send(t,s="GET"){t="string"==typeof t?{url:t}:t;let e=this.get;return"POST"===s&&(e=this.post),new Promise((s,i)=>{e.call(this,t,(t,e,o)=>{t?i(t):s(e)})})}get(t){return this.send.call(this.env,t)}post(t){return this.send.call(this.env,t,"POST")}}return new class{constructor(t,s){this.name=t,this.http=new e(this),this.data=null,this.dataFile="box.dat",this.logs=[],this.isMute=!1,this.logSeparator="\n",this.startTime=(new Date).getTime(),Object.assign(this,s),this.log("",`\ud83d\udd14${this.name}, \u5f00\u59cb!`)}isNode(){return"undefined"!=typeof module&&!!module.exports}isQuanX(){return"undefined"!=typeof $task}isSurge(){return"undefined"!=typeof $httpClient&&"undefined"==typeof $loon}isLoon(){return"undefined"!=typeof $loon}toObj(t,s=null){try{return JSON.parse(t)}catch{return s}}toStr(t,s=null){try{return JSON.stringify(t)}catch{return s}}getjson(t,s){let e=s;const i=this.getdata(t);if(i)try{e=JSON.parse(this.getdata(t))}catch{}return e}setjson(t,s){try{return this.setdata(JSON.stringify(t),s)}catch{return!1}}getScript(t){return new Promise(s=>{this.get({url:t},(t,e,i)=>s(i))})}runScript(t,s){return new Promise(e=>{let i=this.getdata("@chavy_boxjs_userCfgs.httpapi");i=i?i.replace(/\n/g,"").trim():i;let o=this.getdata("@chavy_boxjs_userCfgs.httpapi_timeout");o=o?1*o:20,o=s&&s.timeout?s.timeout:o;const[h,a]=i.split("@"),r={url:`http://${a}/v1/scripting/evaluate`,body:{script_text:t,mock_type:"cron",timeout:o},headers:{"X-Key":h,Accept:"*/*"}};this.post(r,(t,s,i)=>e(i))}).catch(t=>this.logErr(t))}loaddata(){if(!this.isNode())return{};{this.fs=this.fs?this.fs:require("fs"),this.path=this.path?this.path:require("path");const t=this.path.resolve(this.dataFile),s=this.path.resolve(process.cwd(),this.dataFile),e=this.fs.existsSync(t),i=!e&&this.fs.existsSync(s);if(!e&&!i)return{};{const i=e?t:s;try{return JSON.parse(this.fs.readFileSync(i))}catch(t){return{}}}}}writedata(){if(this.isNode()){this.fs=this.fs?this.fs:require("fs"),this.path=this.path?this.path:require("path");const t=this.path.resolve(this.dataFile),s=this.path.resolve(process.cwd(),this.dataFile),e=this.fs.existsSync(t),i=!e&&this.fs.existsSync(s),o=JSON.stringify(this.data);e?this.fs.writeFileSync(t,o):i?this.fs.writeFileSync(s,o):this.fs.writeFileSync(t,o)}}lodash_get(t,s,e){const i=s.replace(/\[(\d+)\]/g,".$1").split(".");let o=t;for(const t of i)if(o=Object(o)[t],void 0===o)return e;return o}lodash_set(t,s,e){return Object(t)!==t?t:(Array.isArray(s)||(s=s.toString().match(/[^.[\]]+/g)||[]),s.slice(0,-1).reduce((t,e,i)=>Object(t[e])===t[e]?t[e]:t[e]=Math.abs(s[i+1])>>0==+s[i+1]?[]:{},t)[s[s.length-1]]=e,t)}getdata(t){let s=this.getval(t);if(/^@/.test(t)){const[,e,i]=/^@(.*?)\.(.*?)$/.exec(t),o=e?this.getval(e):"";if(o)try{const t=JSON.parse(o);s=t?this.lodash_get(t,i,""):s}catch(t){s=""}}return s}setdata(t,s){let e=!1;if(/^@/.test(s)){const[,i,o]=/^@(.*?)\.(.*?)$/.exec(s),h=this.getval(i),a=i?"null"===h?null:h||"{}":"{}";try{const s=JSON.parse(a);this.lodash_set(s,o,t),e=this.setval(JSON.stringify(s),i)}catch(s){const h={};this.lodash_set(h,o,t),e=this.setval(JSON.stringify(h),i)}}else e=this.setval(t,s);return e}getval(t){return this.isSurge()||this.isLoon()?$persistentStore.read(t):this.isQuanX()?$prefs.valueForKey(t):this.isNode()?(this.data=this.loaddata(),this.data[t]):this.data&&this.data[t]||null}setval(t,s){return this.isSurge()||this.isLoon()?$persistentStore.write(t,s):this.isQuanX()?$prefs.setValueForKey(t,s):this.isNode()?(this.data=this.loaddata(),this.data[s]=t,this.writedata(),!0):this.data&&this.data[s]||null}initGotEnv(t){this.got=this.got?this.got:require("got"),this.cktough=this.cktough?this.cktough:require("tough-cookie"),this.ckjar=this.ckjar?this.ckjar:new this.cktough.CookieJar,t&&(t.headers=t.headers?t.headers:{},void 0===t.headers.Cookie&&void 0===t.cookieJar&&(t.cookieJar=this.ckjar))}get(t,s=(()=>{})){t.headers&&(delete t.headers["Content-Type"],delete t.headers["Content-Length"]),this.isSurge()||this.isLoon()?$httpClient.get(t,(t,e,i)=>{!t&&e&&(e.body=i,e.statusCode=e.status),s(t,e,i)}):this.isQuanX()?$task.fetch(t).then(t=>{const{statusCode:e,statusCode:i,headers:o,body:h}=t;s(null,{status:e,statusCode:i,headers:o,body:h},h)},t=>s(t)):this.isNode()&&(this.initGotEnv(t),this.got(t).on("redirect",(t,s)=>{try{const e=t.headers["set-cookie"].map(this.cktough.Cookie.parse).toString();this.ckjar.setCookieSync(e,null),s.cookieJar=this.ckjar}catch(t){this.logErr(t)}}).then(t=>{const{statusCode:e,statusCode:i,headers:o,body:h}=t;s(null,{status:e,statusCode:i,headers:o,body:h},h)},t=>s(t)))}post(t,s=(()=>{})){if(t.body&&t.headers&&!t.headers["Content-Type"]&&(t.headers["Content-Type"]="application/x-www-form-urlencoded"),t.headers&&delete t.headers["Content-Length"],this.isSurge()||this.isLoon())$httpClient.post(t,(t,e,i)=>{!t&&e&&(e.body=i,e.statusCode=e.status),s(t,e,i)});else if(this.isQuanX())t.method="POST",$task.fetch(t).then(t=>{const{statusCode:e,statusCode:i,headers:o,body:h}=t;s(null,{status:e,statusCode:i,headers:o,body:h},h)},t=>s(t));else if(this.isNode()){this.initGotEnv(t);const{url:e,...i}=t;this.got.post(e,i).then(t=>{const{statusCode:e,statusCode:i,headers:o,body:h}=t;s(null,{status:e,statusCode:i,headers:o,body:h},h)},t=>s(t))}}time(t){let s={"M+":(new Date).getMonth()+1,"d+":(new Date).getDate(),"H+":(new Date).getHours(),"m+":(new Date).getMinutes(),"s+":(new Date).getSeconds(),"q+":Math.floor(((new Date).getMonth()+3)/3),S:(new Date).getMilliseconds()};/(y+)/.test(t)&&(t=t.replace(RegExp.$1,((new Date).getFullYear()+"").substr(4-RegExp.$1.length)));for(let e in s)new RegExp("("+e+")").test(t)&&(t=t.replace(RegExp.$1,1==RegExp.$1.length?s[e]:("00"+s[e]).substr((""+s[e]).length)));return t}msg(s=t,e="",i="",o){const h=t=>!t||!this.isLoon()&&this.isSurge()?t:"string"==typeof t?this.isLoon()?t:this.isQuanX()?{"open-url":t}:void 0:"object"==typeof t&&(t["open-url"]||t["media-url"])?this.isLoon()?t["open-url"]:this.isQuanX()?t:void 0:void 0;this.isMute||(this.isSurge()||this.isLoon()?$notification.post(s,e,i,h(o)):this.isQuanX()&&$notify(s,e,i,h(o)));let a=["","==============\ud83d\udce3\u7cfb\u7edf\u901a\u77e5\ud83d\udce3=============="];a.push(s),e&&a.push(e),i&&a.push(i),console.log(a.join("\n")),this.logs=this.logs.concat(a)}log(...t){t.length>0&&(this.logs=[...this.logs,...t]),console.log(t.join(this.logSeparator))}logErr(t,s){const e=!this.isSurge()&&!this.isQuanX()&&!this.isLoon();e?this.log("",`\u2757\ufe0f${this.name}, \u9519\u8bef!`,t.stack):this.log("",`\u2757\ufe0f${this.name}, \u9519\u8bef!`,t)}wait(t){return new Promise(s=>setTimeout(s,t))}done(t={}){const s=(new Date).getTime(),e=(s-this.startTime)/1e3;this.log("",`\ud83d\udd14${this.name}, \u7ed3\u675f! \ud83d\udd5b ${e} \u79d2`),this.log(),(this.isSurge()||this.isQuanX()||this.isLoon())&&$done(t)}}(t,s)}
 
-// HTTP utility function, original source: https://github.com/Peng-YM/QuanX/tree/master/Tools/OpenAPI/API.js
-
-// prettier-ignore
-function ENV(){const e="undefined"!=typeof $task,n="undefined"!=typeof $loon,o="undefined"!=typeof $httpClient&&!this.isLoon,i="function"==typeof require&&"undefined"!=typeof $jsbox;return{isQX:e,isLoon:n,isSurge:o,isNode:"function"==typeof require&&!i,isJSBox:i}}
-function HTTP(e,t={}){const{isQX:o,isLoon:s,isSurge:n}=ENV();const r={};return["GET","POST","PUT","DELETE","HEAD","OPTIONS","PATCH"].forEach(u=>r[u.toLowerCase()]=(r=>(function(r,u){(u="string"==typeof u?{url:u}:u).url=e?e+u.url:u.url;const i=(u={...t,...u}).timeout,T={onRequest:()=>{},onResponse:e=>e,onTimeout:()=>{},...u.events};let a,c;T.onRequest(r,u),a=o?$task.fetch({method:r,...u}):new Promise((e,t)=>{(n||s?$httpClient:require("request"))[r.toLowerCase()](u,(o,s,n)=>{o?t(o):e({statusCode:s.status||s.statusCode,headers:s.headers,body:n})})});const m=i?new Promise((e,t)=>{c=setTimeout(()=>(T.onTimeout(),t(`${r} URL: ${u.url} exceeds the timeout ${i} ms`)),i)}):null;return(m?Promise.race([m,a]).then(e=>(clearTimeout(c),e)):a).then(e=>T.onResponse(e))})(u,r))),r}
+// Gist备份
+function GistBox(e){const t=function(e,t={}){const{isQX:s,isLoon:n,isSurge:o}=function(){const e="undefined"!=typeof $task,t="undefined"!=typeof $loon,s="undefined"!=typeof $httpClient&&!this.isLoon,n="function"==typeof require&&"undefined"!=typeof $jsbox;return{isQX:e,isLoon:t,isSurge:s,isNode:"function"==typeof require&&!n,isJSBox:n}}(),r={};return["GET","POST","PUT","DELETE","HEAD","OPTIONS","PATCH"].forEach(i=>r[i.toLowerCase()]=(r=>(function(r,i){(i="string"==typeof i?{url:i}:i).url=e?e+i.url:i.url;const a=(i={...t,...i}).timeout,u={onRequest:()=>{},onResponse:e=>e,onTimeout:()=>{},...i.events};let c,d;u.onRequest(r,i),c=s?$task.fetch({method:r,...i}):new Promise((e,t)=>{(o||n?$httpClient:require("request"))[r.toLowerCase()](i,(s,n,o)=>{s?t(s):e({statusCode:n.status||n.statusCode,headers:n.headers,body:o})})});const f=a?new Promise((e,t)=>{d=setTimeout(()=>(u.onTimeout(),t(`${r} URL: ${i.url} exceeds the timeout ${a} ms`)),a)}):null;return(f?Promise.race([f,c]).then(e=>(clearTimeout(d),e)):c).then(e=>u.onResponse(e))})(i,r))),r}("https://api.github.com",{headers:{Authorization:`token ${e}`,"User-Agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.141 Safari/537.36"},events:{onResponse:e=>String(e.statusCode).startsWith("4")?Promise.reject(`ERROR: ${JSON.parse(e.body).message}`):e}}),s=e=>`boxjs.bak.${e}.json`,n=e=>e.match(/boxjs\.bak\.(\d+)\.json/)[1];return new class{async findDatabase(){return t.get("/gists").then(e=>{const t=JSON.parse(e.body);for(let e of t)if("BoxJs Gist"===e.description)return e.id;return-1})}async createDatabase(e){e instanceof Array||(e=[e]);const n={};return e.forEach(e=>{n[s(e.time)]={content:e.content}}),t.post({url:"/gists",body:JSON.stringify({description:"BoxJs Gist",public:!1,files:n})}).then(e=>JSON.parse(e.body).id)}async deleteDatabase(e){return t.delete(`/gists/${e}`)}async getBackups(e){const s=await t.get(`/gists/${e}`).then(e=>JSON.parse(e.body)),{files:o}=s,r=[];for(let e of Object.keys(o))r.push({time:n(e),url:o[e].raw_url});return r}async addBackups(e,t){t instanceof Array||(t=[t]);const n={};return t.forEach(e=>n[s(e.time)]={content:e.content}),this.updateBackups(e,n)}async deleteBackups(e,t){t instanceof Array||(t=[t]);const n={};return t.forEach(e=>n[s(e)]={}),this.updateBackups(e,n)}async updateBackups(e,s){return t.patch({url:`/gists/${e}`,body:JSON.stringify({files:s})})}}}

--- a/box/chavy.boxjs.js
+++ b/box/chavy.boxjs.js
@@ -505,6 +505,104 @@ async function apiRunScript() {
  * 工具类函数
  * ===================================
  */
+// gist备份工具
+function GistBox(token) {
+  const BOX_BACKUP_KEY = "BoxJs Gist";
+  const $http = HTTP("https://api.github.com", {
+    headers: {
+      Authorization: `token ${token}`,
+      "User-Agent":
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.141 Safari/537.36",
+    },
+    events: {
+      onResponse: (resp) => {
+        if (String(resp.statusCode).startsWith("4")) {
+          return Promise.reject(`ERROR: ${JSON.parse(resp.body).message}`);
+        } else {
+          return resp;
+        }
+      },
+    },
+  });
+  const genFileName = (timestamp) => `boxjs.bak.${timestamp}.json`;
+  const genTimestamp = (fname) => fname.match(/boxjs\.bak\.(\d+)\.json/)[1];
+
+  return new (class {
+    async findDatabase() {
+      return $http.get("/gists").then((response) => {
+        const gists = JSON.parse(response.body);
+        for (let g of gists) {
+          if (g.description === BOX_BACKUP_KEY) {
+            return g.id;
+          }
+        }
+        return -1;
+      });
+    }
+
+    async createDatabase(backups) {
+      if (!(backups instanceof Array)) backups = [backups];
+      const files = {};
+      backups.forEach((b) => {
+        files[genFileName(b.time)] = {
+          content: b.content,
+        };
+      });
+      return $http
+        .post({
+          url: "/gists",
+          body: JSON.stringify({
+            description: BOX_BACKUP_KEY,
+            public: false,
+            files,
+          }),
+        })
+        .then((resp) => {
+          return JSON.parse(resp.body).id;
+        });
+    }
+
+    async deleteDatabase(id) {
+      return $http.delete(`/gists/${id}`);
+    }
+
+    async getBackups(id) {
+      const gist = await $http
+        .get(`/gists/${id}`)
+        .then((resp) => JSON.parse(resp.body));
+      const { files } = gist;
+      const backups = [];
+      for (let name of Object.keys(files)) {
+        backups.push({
+          time: genTimestamp(name),
+          url: files[name].raw_url,
+        });
+      }
+      return backups;
+    }
+
+    async addBackups(id, backups) {
+      if (!(backups instanceof Array)) backups = [backups];
+      const files = {};
+      backups.forEach((b) => (files[genFileName(b.time)] = {content: b.content}));
+      return this.updateBackups(id, files);
+    }
+
+    async deleteBackups(id, timestamps) {
+      if (!(timestamps instanceof Array)) timestamps = [timestamps];
+      const files = {};
+      timestamps.forEach((t) => (files[genFileName(t)] = {}));
+      return this.updateBackups(id, files);
+    }
+
+    async updateBackups(id, files) {
+      return $http.patch({
+        url: `/gists/${id}`,
+        body: JSON.stringify({ files }),
+      });
+    }
+  })();
+}
 
 function reloadAppSubCache(url) {
   return $.http.get(url).then((resp) => {
@@ -633,3 +731,9 @@ function doneApi() {
 
 // prettier-ignore
 function Env(t,s){class e{constructor(t){this.env=t}send(t,s="GET"){t="string"==typeof t?{url:t}:t;let e=this.get;return"POST"===s&&(e=this.post),new Promise((s,i)=>{e.call(this,t,(t,e,o)=>{t?i(t):s(e)})})}get(t){return this.send.call(this.env,t)}post(t){return this.send.call(this.env,t,"POST")}}return new class{constructor(t,s){this.name=t,this.http=new e(this),this.data=null,this.dataFile="box.dat",this.logs=[],this.isMute=!1,this.logSeparator="\n",this.startTime=(new Date).getTime(),Object.assign(this,s),this.log("",`\ud83d\udd14${this.name}, \u5f00\u59cb!`)}isNode(){return"undefined"!=typeof module&&!!module.exports}isQuanX(){return"undefined"!=typeof $task}isSurge(){return"undefined"!=typeof $httpClient&&"undefined"==typeof $loon}isLoon(){return"undefined"!=typeof $loon}toObj(t,s=null){try{return JSON.parse(t)}catch{return s}}toStr(t,s=null){try{return JSON.stringify(t)}catch{return s}}getjson(t,s){let e=s;const i=this.getdata(t);if(i)try{e=JSON.parse(this.getdata(t))}catch{}return e}setjson(t,s){try{return this.setdata(JSON.stringify(t),s)}catch{return!1}}getScript(t){return new Promise(s=>{this.get({url:t},(t,e,i)=>s(i))})}runScript(t,s){return new Promise(e=>{let i=this.getdata("@chavy_boxjs_userCfgs.httpapi");i=i?i.replace(/\n/g,"").trim():i;let o=this.getdata("@chavy_boxjs_userCfgs.httpapi_timeout");o=o?1*o:20,o=s&&s.timeout?s.timeout:o;const[h,a]=i.split("@"),r={url:`http://${a}/v1/scripting/evaluate`,body:{script_text:t,mock_type:"cron",timeout:o},headers:{"X-Key":h,Accept:"*/*"}};this.post(r,(t,s,i)=>e(i))}).catch(t=>this.logErr(t))}loaddata(){if(!this.isNode())return{};{this.fs=this.fs?this.fs:require("fs"),this.path=this.path?this.path:require("path");const t=this.path.resolve(this.dataFile),s=this.path.resolve(process.cwd(),this.dataFile),e=this.fs.existsSync(t),i=!e&&this.fs.existsSync(s);if(!e&&!i)return{};{const i=e?t:s;try{return JSON.parse(this.fs.readFileSync(i))}catch(t){return{}}}}}writedata(){if(this.isNode()){this.fs=this.fs?this.fs:require("fs"),this.path=this.path?this.path:require("path");const t=this.path.resolve(this.dataFile),s=this.path.resolve(process.cwd(),this.dataFile),e=this.fs.existsSync(t),i=!e&&this.fs.existsSync(s),o=JSON.stringify(this.data);e?this.fs.writeFileSync(t,o):i?this.fs.writeFileSync(s,o):this.fs.writeFileSync(t,o)}}lodash_get(t,s,e){const i=s.replace(/\[(\d+)\]/g,".$1").split(".");let o=t;for(const t of i)if(o=Object(o)[t],void 0===o)return e;return o}lodash_set(t,s,e){return Object(t)!==t?t:(Array.isArray(s)||(s=s.toString().match(/[^.[\]]+/g)||[]),s.slice(0,-1).reduce((t,e,i)=>Object(t[e])===t[e]?t[e]:t[e]=Math.abs(s[i+1])>>0==+s[i+1]?[]:{},t)[s[s.length-1]]=e,t)}getdata(t){let s=this.getval(t);if(/^@/.test(t)){const[,e,i]=/^@(.*?)\.(.*?)$/.exec(t),o=e?this.getval(e):"";if(o)try{const t=JSON.parse(o);s=t?this.lodash_get(t,i,""):s}catch(t){s=""}}return s}setdata(t,s){let e=!1;if(/^@/.test(s)){const[,i,o]=/^@(.*?)\.(.*?)$/.exec(s),h=this.getval(i),a=i?"null"===h?null:h||"{}":"{}";try{const s=JSON.parse(a);this.lodash_set(s,o,t),e=this.setval(JSON.stringify(s),i)}catch(s){const h={};this.lodash_set(h,o,t),e=this.setval(JSON.stringify(h),i)}}else e=this.setval(t,s);return e}getval(t){return this.isSurge()||this.isLoon()?$persistentStore.read(t):this.isQuanX()?$prefs.valueForKey(t):this.isNode()?(this.data=this.loaddata(),this.data[t]):this.data&&this.data[t]||null}setval(t,s){return this.isSurge()||this.isLoon()?$persistentStore.write(t,s):this.isQuanX()?$prefs.setValueForKey(t,s):this.isNode()?(this.data=this.loaddata(),this.data[s]=t,this.writedata(),!0):this.data&&this.data[s]||null}initGotEnv(t){this.got=this.got?this.got:require("got"),this.cktough=this.cktough?this.cktough:require("tough-cookie"),this.ckjar=this.ckjar?this.ckjar:new this.cktough.CookieJar,t&&(t.headers=t.headers?t.headers:{},void 0===t.headers.Cookie&&void 0===t.cookieJar&&(t.cookieJar=this.ckjar))}get(t,s=(()=>{})){t.headers&&(delete t.headers["Content-Type"],delete t.headers["Content-Length"]),this.isSurge()||this.isLoon()?$httpClient.get(t,(t,e,i)=>{!t&&e&&(e.body=i,e.statusCode=e.status),s(t,e,i)}):this.isQuanX()?$task.fetch(t).then(t=>{const{statusCode:e,statusCode:i,headers:o,body:h}=t;s(null,{status:e,statusCode:i,headers:o,body:h},h)},t=>s(t)):this.isNode()&&(this.initGotEnv(t),this.got(t).on("redirect",(t,s)=>{try{const e=t.headers["set-cookie"].map(this.cktough.Cookie.parse).toString();this.ckjar.setCookieSync(e,null),s.cookieJar=this.ckjar}catch(t){this.logErr(t)}}).then(t=>{const{statusCode:e,statusCode:i,headers:o,body:h}=t;s(null,{status:e,statusCode:i,headers:o,body:h},h)},t=>s(t)))}post(t,s=(()=>{})){if(t.body&&t.headers&&!t.headers["Content-Type"]&&(t.headers["Content-Type"]="application/x-www-form-urlencoded"),t.headers&&delete t.headers["Content-Length"],this.isSurge()||this.isLoon())$httpClient.post(t,(t,e,i)=>{!t&&e&&(e.body=i,e.statusCode=e.status),s(t,e,i)});else if(this.isQuanX())t.method="POST",$task.fetch(t).then(t=>{const{statusCode:e,statusCode:i,headers:o,body:h}=t;s(null,{status:e,statusCode:i,headers:o,body:h},h)},t=>s(t));else if(this.isNode()){this.initGotEnv(t);const{url:e,...i}=t;this.got.post(e,i).then(t=>{const{statusCode:e,statusCode:i,headers:o,body:h}=t;s(null,{status:e,statusCode:i,headers:o,body:h},h)},t=>s(t))}}time(t){let s={"M+":(new Date).getMonth()+1,"d+":(new Date).getDate(),"H+":(new Date).getHours(),"m+":(new Date).getMinutes(),"s+":(new Date).getSeconds(),"q+":Math.floor(((new Date).getMonth()+3)/3),S:(new Date).getMilliseconds()};/(y+)/.test(t)&&(t=t.replace(RegExp.$1,((new Date).getFullYear()+"").substr(4-RegExp.$1.length)));for(let e in s)new RegExp("("+e+")").test(t)&&(t=t.replace(RegExp.$1,1==RegExp.$1.length?s[e]:("00"+s[e]).substr((""+s[e]).length)));return t}msg(s=t,e="",i="",o){const h=t=>!t||!this.isLoon()&&this.isSurge()?t:"string"==typeof t?this.isLoon()?t:this.isQuanX()?{"open-url":t}:void 0:"object"==typeof t&&(t["open-url"]||t["media-url"])?this.isLoon()?t["open-url"]:this.isQuanX()?t:void 0:void 0;this.isMute||(this.isSurge()||this.isLoon()?$notification.post(s,e,i,h(o)):this.isQuanX()&&$notify(s,e,i,h(o)));let a=["","==============\ud83d\udce3\u7cfb\u7edf\u901a\u77e5\ud83d\udce3=============="];a.push(s),e&&a.push(e),i&&a.push(i),console.log(a.join("\n")),this.logs=this.logs.concat(a)}log(...t){t.length>0&&(this.logs=[...this.logs,...t]),console.log(t.join(this.logSeparator))}logErr(t,s){const e=!this.isSurge()&&!this.isQuanX()&&!this.isLoon();e?this.log("",`\u2757\ufe0f${this.name}, \u9519\u8bef!`,t.stack):this.log("",`\u2757\ufe0f${this.name}, \u9519\u8bef!`,t)}wait(t){return new Promise(s=>setTimeout(s,t))}done(t={}){const s=(new Date).getTime(),e=(s-this.startTime)/1e3;this.log("",`\ud83d\udd14${this.name}, \u7ed3\u675f! \ud83d\udd5b ${e} \u79d2`),this.log(),(this.isSurge()||this.isQuanX()||this.isLoon())&&$done(t)}}(t,s)}
+
+// HTTP utility function, original source: https://github.com/Peng-YM/QuanX/tree/master/Tools/OpenAPI/API.js
+
+// prettier-ignore
+function ENV(){const e="undefined"!=typeof $task,n="undefined"!=typeof $loon,o="undefined"!=typeof $httpClient&&!this.isLoon,i="function"==typeof require&&"undefined"!=typeof $jsbox;return{isQX:e,isLoon:n,isSurge:o,isNode:"function"==typeof require&&!i,isJSBox:i}}
+function HTTP(e,t={}){const{isQX:o,isLoon:s,isSurge:n}=ENV();const r={};return["GET","POST","PUT","DELETE","HEAD","OPTIONS","PATCH"].forEach(u=>r[u.toLowerCase()]=(r=>(function(r,u){(u="string"==typeof u?{url:u}:u).url=e?e+u.url:u.url;const i=(u={...t,...u}).timeout,T={onRequest:()=>{},onResponse:e=>e,onTimeout:()=>{},...u.events};let a,c;T.onRequest(r,u),a=o?$task.fetch({method:r,...u}):new Promise((e,t)=>{(n||s?$httpClient:require("request"))[r.toLowerCase()](u,(o,s,n)=>{o?t(o):e({statusCode:s.status||s.statusCode,headers:s.headers,body:n})})});const m=i?new Promise((e,t)=>{c=setTimeout(()=>(T.onTimeout(),t(`${r} URL: ${u.url} exceeds the timeout ${i} ms`)),i)}):null;return(m?Promise.race([m,a]).then(e=>(clearTimeout(c),e)):a).then(e=>T.onResponse(e))})(u,r))),r}


### PR DESCRIPTION
## Gist备份小工具

实现了一个小工具用于备份Box备份到gist。简单列出一些用法：

```javascript
const $gist = GistBox("「填入github的token」"); // 注意需要有读取私有gist的权限
```

在用户gist列表中查找box备份的数据库（即：单个gist）。**id是数据库唯一标识。**

```javascript
// 查询成功，返回数据库id；失败返回-1。
id = await $gist.findDatabase();
```

使用备份数据创建一个新的数据库，注意**由于github限制，不允许创建不包含任何文件的gist**。

```javascript
// backups 是一个数组，每个item的属性为time和content，也可以是单独的一个item
backups = [
  {
    time: "一个时间戳",
    content: "字符串格式的内容"
  },
  {
    ...
  }
];
// 创建成功，返回id；失败则返回Promise.reject并给出错误信息。
id = await $gist.createDatabase(backups);
```

根据id删除数据库：

```javascript
// 失败则返回Promise.reject并给出错误信息。
await $gist.deleteDatabase(id);
```

获取数据库中所有备份。由于备份内容可能非常大，所以该接口只返回备份的URL，内容需要二次获取（比如恢复备份时获取）。**时间戳是某个备份的唯一标识符**。

```javascript
backups = await $gist.getBackups(id);

// 下面是返回数据的样例
backups = [
  {
    time: "时间戳",
    url: "该备份的URL"
  },
  {
    ...
  }
]
```

上传或者修改一个（或者多个）备份。修改的话只要保持时间戳一致即可更新原有备份。

```javascript
// 也可以传入一个数组，每个item格式都和这个一样
backup = {
    time: "一个时间戳",
    content: "字符串格式的内容"
}
await $gist.addBackups(id, backup);
```

删除一个（或者多个）备份。传入时间戳（一个或者数组）即可。

```javascript
timestamps = ['xxx', 'yyy', 'zzz'];
await $gist.deleteBackups(id, timestamps)
```


