### PR TITLE
修复key报错，以及开发环境的插件实例丢失错误

### DIFF
--- a/box/chavy.boxjs.html
+++ b/box/chavy.boxjs.html
@@ -458,8 +458,8 @@
                 </v-expansion-panel-header>
                 <v-expansion-panel-content>
                   <v-list dense nav class="ma-n4">
-                    <template v-for="(app, appIdx) in favApps" :key="app.id">
-                      <v-list-item dense @click="switchAppView(app.id)">
+                    <template v-for="(app, appIdx) in favApps">
+                      <v-list-item dense @click="switchAppView(app.id)" :key="app.id">
                         <v-list-item-avatar class="elevation-3"><v-img :src="app.icon" /></v-list-item-avatar>
                         <v-list-item-content>
                           <v-list-item-title>{{app.name}} ({{app.id}})</v-list-item-title>
@@ -500,8 +500,8 @@
                 </v-expansion-panel-header>
                 <v-expansion-panel-content>
                   <v-list dense nav class="ma-n4">
-                    <template v-for="(app, appIdx) in sub.apps" :key="app.id">
-                      <v-list-item dense @click="switchAppView(app.id)">
+                    <template v-for="(app, appIdx) in sub.apps">
+                      <v-list-item dense @click="switchAppView(app.id)" :key="app.id">
                         <v-list-item-avatar class="elevation-3"><v-img :src="app.icon" /></v-list-item-avatar>
                         <v-list-item-content>
                           <v-list-item-title>{{app.name}} ({{app.id}})</v-list-item-title>
@@ -528,8 +528,8 @@
                 </v-expansion-panel-header>
                 <v-expansion-panel-content>
                   <v-list dense nav class="ma-n4">
-                    <template v-for="(app, appIdx) in sysApps" :key="app.id">
-                      <v-list-item dense @click="switchAppView(app.id)">
+                    <template v-for="(app, appIdx) in sysApps">
+                      <v-list-item dense @click="switchAppView(app.id)" :key="app.id">
                         <v-list-item-avatar class="elevation-3"><v-img :src="app.icon" /></v-list-item-avatar>
                         <v-list-item-content>
                           <v-list-item-title>{{app.name}} ({{app.id}})</v-list-item-title>
@@ -882,8 +882,8 @@
                     <v-icon color="primary" @click="addAppSubDialog = true">mdi-plus-circle</v-icon>
                   </v-btn>
                 </v-subheader>
-                <template v-for="(sub, subIdx) in appSubs" :key="sub.id">
-                  <v-list-item dense two-line @click="reloadAppSub(sub)">
+                <template v-for="(sub, subIdx) in appSubs">
+                  <v-list-item dense two-line @click="reloadAppSub(sub)" :key="sub.id">
                     <v-list-item-avatar v-if="sub.icon"><v-img :src="sub.icon" /></v-list-item-avatar>
                     <v-list-item-avatar v-else color="primary"><v-icon dark>mdi-account</v-icon></v-list-item-avatar>
                     <v-list-item-content>
@@ -1166,6 +1166,9 @@
     <script src="https://cdn.jsdelivr.net/npm/vue-clipboard2@0.x/dist/vue-clipboard.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/monaco-editor@0.20.0/min/vs/loader.js"></script>
     <script>
+      Vue.prototype.timeago = timeago
+      Vue.prototype.dayjs = dayjs
+
       new Vue({
         el: '#app',
         vuetify: new Vuetify(),


### PR DESCRIPTION
1、cannot be keyed. Place the key on real elements instead.
2、Property or method "dayjs" is not defined on the instance but referenced during render. Make sure that this property is reactive, either in the data option, or for class-based components, by initializing the property. See: https://vuejs.org/v2/guide/reactivity.html#Declaring-Reactive-Properties.