### PR TITLE
更新[BoxJs]: 应用会话前，清空当前会话数据

### DIFF
--- a/box/chavy.boxjs.html
+++ b/box/chavy.boxjs.html
@@ -2150,6 +2150,8 @@
             const val = JSON.stringify(this.box.curSessions)
             const curSessions = [{ key, val }]
             const datas = [...session.datas, ...curSessions]
+            
+            this.clearAppDatas()
             axios.post('/api/save', datas).then((resp) => {
               delete resp.data.usercfgs
               Object.assign(this.box, resp.data)

--- a/box/chavy.boxjs.html
+++ b/box/chavy.boxjs.html
@@ -2150,7 +2150,7 @@
             const val = JSON.stringify(this.box.curSessions)
             const curSessions = [{ key, val }]
             const datas = [...session.datas, ...curSessions]
-            
+
             this.clearAppDatas()
             axios.post('/api/save', datas).then((resp) => {
               delete resp.data.usercfgs

--- a/box/chavy.boxjs.js
+++ b/box/chavy.boxjs.js
@@ -3,7 +3,7 @@ const $ = new Env('BoxJs')
 // 为 eval 准备的上下文环境
 const $eval_env = {}
 
-$.version = '0.7.64'
+$.version = '0.7.65'
 $.versionType = 'beta'
 
 // 发出的请求需要需要 Surge、QuanX 的 rewrite

--- a/box/release/box.release.json
+++ b/box/release/box.release.json
@@ -1,6 +1,22 @@
 {
   "releases": [
     {
+      "version": "0.7.65",
+      "tags": ["beta"],
+      "author": "@id77",
+      "msg": "更新[BoxJs]: 应用会话前，清空当前会话数据",
+      "notes": [
+        {
+          "name": "优化",
+          "descs": ["应用会话前，清空当前会话数据"]
+        },
+        {
+          "name": "感谢",
+          "descs": ["@id77 PR"]
+        }
+      ]
+    },
+    {
       "version": "0.7.64",
       "tags": ["beta"],
       "author": "@whyour",

--- a/box/release/box.release.tf.json
+++ b/box/release/box.release.tf.json
@@ -1,6 +1,22 @@
 {
   "releases": [
     {
+      "version": "0.7.65",
+      "tags": ["beta"],
+      "author": "@id77",
+      "msg": "更新[BoxJs]: 应用会话前，清空当前会话数据",
+      "notes": [
+        {
+          "name": "优化",
+          "descs": ["应用会话前，清空当前会话数据"]
+        },
+        {
+          "name": "感谢",
+          "descs": ["@id77 PR"]
+        }
+      ]
+    },
+    {
       "version": "0.7.64",
       "tags": ["beta"],
       "author": "@whyour",

--- a/chavy.box.js
+++ b/chavy.box.js
@@ -3,7 +3,7 @@ const $ = new Env('BoxJs')
 // 为 eval 准备的上下文环境
 const $eval_env = {}
 
-$.version = '0.7.64'
+$.version = '0.7.65'
 $.versionType = 'beta'
 
 // 发出的请求需要需要 Surge、QuanX 的 rewrite


### PR DESCRIPTION
在订阅更新后，有的app数据存在新增字段；不清空直接应用，会导致上个会话新增字段的内容还保留在当前会话。

本次修改HTML文件，需要发版。