### PR TITLE
add(key): 增加 chavy_boxjs_userCfgs.gist_cache_key，用于存储通过 boxjs 数据查看器保存…

### DIFF
--- a/box/chavy.boxjs.js
+++ b/box/chavy.boxjs.js
@@ -312,6 +312,14 @@ async function handleOptions() {}
 
 function getBoxData() {
   const datas = {}
+  
+  const extraDatas =
+    $.getdata(`${$.KEY_usercfgs.replace('#', '@')}.gist_cache_key`) || []
+
+  extraDatas.forEach((key) => {
+    datas[key] = $.getdata(key)
+  })
+
   const usercfgs = getUserCfgs()
   const sessions = getAppSessions()
   const curSessions = getCurSessions()


### PR DESCRIPTION
…内容的 key，以便于 gist 备份时，数据不丢失