### PR TITLE
fix: validate cookie/url before setCookie to prevent tough-cookie [ob…

### DIFF
--- a/Env.js
+++ b/Env.js
@@ -415,15 +415,25 @@ function Env(name, opts) {
           this.got(request)
             .on('redirect', (resp, nextOpts) => {
               try {
-                if (resp.headers['set-cookie']) {
-                  const ck = resp.headers['set-cookie']
-                    .map(this.cktough.Cookie.parse)
-                    .toString()
-                  if (ck) {
-                    this.ckjar.setCookieSync(ck, null)
+                const currentUrl =
+                  resp.url ||
+                  resp.request?.requestUrl ||
+                  resp.request?.options?.url ||
+                  nextOpts.url
+                const setCookie = resp.headers?.['set-cookie']
+                const cookieList = Array.isArray(setCookie)
+                  ? setCookie
+                  : [setCookie]
+                for (const ck of cookieList) {
+                  try {
+                    if (ck && currentUrl) {
+                      this.ckjar.setCookieSync(ck, String(currentUrl))
+                    }
+                  } catch (e) {
+                    this.logErr(e)
                   }
-                  nextOpts.cookieJar = this.ckjar
                 }
+                nextOpts.cookieJar = this.ckjar
               } catch (e) {
                 this.logErr(e)
               }


### PR DESCRIPTION
## 问题
运行时出现 Cookie 写入失败，导致请求流程中断。

## 原始报错
```text
undefined
[object Object]
Error: [object Object]
    at Object.validate (/app/run/node_modules/tough-cookie/lib/validators.js:91:13)
    at CookieJar.setCookie (/app/run/node_modules/tough-cookie/lib/cookie.js:1119:16)
    at CookieJar.setCookie (/app/run/node_modules/universalify/index.js:5:67)
    at CookieJar.setCookieSync (/app/run/node_modules/tough-cookie/lib/cookie.js:1728:17)
    at EventEmitter.<anonymous> (/app/run/sfsyV3.js:389:6914)
    at EventEmitter.emit (node:events:507:28)
    at fns.<computed> (/app/run/node_modules/got/dist/source/core/utils/proxy-events.js:7:16)
    at Request.emit (node:events:507:28)
    at Request._onResponseBase (/app/run/node_modules/got/dist/source/core/index.js:903:22)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)